### PR TITLE
Fix clean command output type

### DIFF
--- a/telegram-download-daemon.py
+++ b/telegram-download-daemon.py
@@ -210,8 +210,13 @@ with TelegramClient(getSession(), api_id, api_hash,
                     except:
                         output = "Some error occured while checking the status. Retry."
                 elif command == "clean":
-                    output = "Cleaning "+tempFolder+"\n"
-                    output+=subprocess.run(["rm "+tempFolder+"/*."+TELEGRAM_DAEMON_TEMP_SUFFIX], shell=True, stdout=subprocess.PIPE,stderr=subprocess.STDOUT).stdout
+                    output = "Cleaning " + tempFolder + "\n"
+                    output += subprocess.run(
+                        "rm " + tempFolder + "/*." + TELEGRAM_DAEMON_TEMP_SUFFIX,
+                        shell=True,
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.STDOUT,
+                    ).stdout.decode("utf-8")
                 elif command == "queue":
                     try:
                         files_in_queue = []


### PR DESCRIPTION
## Summary
- fix string/bytes concatenation in the `clean` command

## Testing
- `python3 -m py_compile telegram-download-daemon.py sessionManager.py`